### PR TITLE
feat: orchestrate co-dm scene composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ Szene abrufen:
 curl http://localhost:8000/scene/1
 ```
 
+Szene komponieren (Mock-LLM):
+
+```bash
+curl -X POST http://localhost:8000/llm/compose_scene \
+  -H 'Content-Type: application/json' \
+  -d '{"scene_id": 1, "party": {"members": ["A"]}}'
+# {
+#   "scene_id": 1,
+#   "narration": "Die Helden betreten eine dunkle Höhle.",
+#   "options": [{"prompt": "Nach Fallen suchen", "check": {"skill": "perception", "dc": 12, "on_success": "Du findest eine Falle.", "on_fail": "Du löst eine Falle aus."}}],
+#   "combat_if_triggered": {"monsters": ["Goblin"], "tactics": "Hinterhalt aus dem Schatten", "terrain": "Höhle", "scaling": "medium"},
+#   "state_updates": []
+# }
+```
+
 State-Update:
 
 ```bash

--- a/app/llm/output_schema.py
+++ b/app/llm/output_schema.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from app.models.schemas import StateUpdate
+
+
+class CheckSpec(BaseModel):
+    skill: str
+    dc: int
+    on_success: str
+    on_fail: str
+
+
+class Option(BaseModel):
+    prompt: str
+    check: CheckSpec
+
+
+class CombatInfo(BaseModel):
+    monsters: list[str]
+    tactics: str
+    terrain: str
+    scaling: str
+
+
+class LLMOutput(BaseModel):
+    scene_id: int
+    narration: str
+    options: list[Option]
+    combat_if_triggered: CombatInfo | None = Field(default=None)
+    state_updates: list[StateUpdate] = Field(default_factory=list)

--- a/app/llm/templates.py
+++ b/app/llm/templates.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from app.models.schemas import Scene
+
+SYSTEM_PROMPT = (
+    "Du bist ein Co-Dungeon-Master. Improvisiere nur innerhalb der aktuellen "
+    "Szene. Biete Vorschläge an, triff keine Entscheidungen."
+)
+
+DEVELOPER_PROMPT = (
+    "Liefere ausschließlich valides JSON entsprechend dem vorgegebenen Schema."
+)
+
+
+def user_prompt(scene: Scene, checks: list[dict], monster: dict) -> str:
+    """Build the user prompt for the LLM."""
+    lines = [
+        f"Szene: {scene.title}",
+    ]
+    if scene.description:
+        lines.append(scene.description)
+    if checks:
+        lines.append("Vorgeschlagene Checks:")
+        for c in checks:
+            lines.append(f"- {c['reason']} (Skill: {c['skill']}, DC {c['dc']})")
+    if monster:
+        lines.append(f"Möglicher Gegner: {monster.get('name')} - {monster.get('type')}")
+    return "\n".join(lines)

--- a/app/llm/validate.py
+++ b/app/llm/validate.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, List, Dict
+
+from fastapi import HTTPException
+from jsonschema import ValidationError as JSONValidationError, validate as json_validate
+from pydantic import ValidationError as PydanticValidationError
+
+from .output_schema import LLMOutput
+
+
+Message = Dict[str, str]
+
+
+def validate_with_retry(
+    llm: Callable[[List[Message]], str],
+    messages: List[Message],
+    max_retries: int = 2,
+) -> LLMOutput:
+    """Call the LLM and validate the JSON response."""
+    schema = LLMOutput.model_json_schema()
+    history = list(messages)
+    for attempt in range(max_retries + 1):
+        raw = llm(history)
+        try:
+            data = json.loads(raw)
+            json_validate(data, schema)
+            return LLMOutput.model_validate(data)
+        except (
+            json.JSONDecodeError,
+            JSONValidationError,
+            PydanticValidationError,
+        ) as exc:
+            logging.info("LLM output invalid on attempt %s: %s", attempt + 1, exc)
+            if attempt >= max_retries:
+                raise HTTPException(
+                    status_code=422, detail="Invalid LLM output"
+                ) from exc
+            history.append({"role": "user", "content": f"Korrigiere das JSON: {exc}"})
+    raise HTTPException(status_code=422, detail="Invalid LLM output")

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from app.routes.scene import router as scene_router
 from app.routes.state import router as state_router
 from app.routes.rules import router as rules_router
 from app.routes.encounter import router as encounter_router
+from app.routes.llm import router as llm_router
 from app.state.db import init_db
 
 app = FastAPI()
@@ -23,3 +24,4 @@ app.include_router(scene_router)
 app.include_router(state_router)
 app.include_router(rules_router)
 app.include_router(encounter_router)
+app.include_router(llm_router)

--- a/app/routes/llm.py
+++ b/app/routes/llm.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.llm.output_schema import LLMOutput
+from app.llm.templates import DEVELOPER_PROMPT, SYSTEM_PROMPT, user_prompt
+from app.llm.validate import validate_with_retry
+from app.models.schemas import Party
+from app.routes.scene import get_scene
+from app.rules.suggest_checks import suggest_checks
+from app.srd.lookup import lookup
+
+router = APIRouter()
+
+
+def default_llm(_: list[dict]) -> str:
+    """Placeholder LLM implementation."""
+    return "{}"
+
+
+def get_llm() -> Callable[[list[dict]], str]:
+    return default_llm
+
+
+class ComposeRequest(BaseModel):
+    scene_id: int
+    party: Party
+
+
+@router.post("/llm/compose_scene", response_model=LLMOutput)
+def compose_scene(
+    req: ComposeRequest, llm: Callable[[list[dict]], str] = Depends(get_llm)
+) -> LLMOutput:
+    scene = get_scene(req.scene_id)
+    checks = suggest_checks(scene.model_dump(), req.party.model_dump())
+    monster = lookup("SRD.goblin")
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "developer", "content": DEVELOPER_PROMPT},
+        {"role": "user", "content": user_prompt(scene, checks, monster)},
+    ]
+    return validate_with_retry(llm, messages)

--- a/docs/Schemas.md
+++ b/docs/Schemas.md
@@ -9,3 +9,31 @@ Die Anwendung verwendet folgende Pydantic-Modelle:
 - `Encounter`
 - `Party`
 - `StateUpdate` / `StateUpdateRequest`
+- `LLMOutput` (Co-DM Antwort)
+
+## LLMOutput
+
+```json
+{
+  "scene_id": 1,
+  "narration": "...",
+  "options": [
+    {
+      "prompt": "...",
+      "check": {
+        "skill": "perception",
+        "dc": 12,
+        "on_success": "...",
+        "on_fail": "..."
+      }
+    }
+  ],
+  "combat_if_triggered": {
+    "monsters": ["Goblin"],
+    "tactics": "...",
+    "terrain": "...",
+    "scaling": "..."
+  },
+  "state_updates": []
+}
+```

--- a/tests/golden_samples/compose_scene_missing_field.json
+++ b/tests/golden_samples/compose_scene_missing_field.json
@@ -1,0 +1,21 @@
+{
+  "scene_id": 1,
+  "options": [
+    {
+      "prompt": "Nach Fallen suchen",
+      "check": {
+        "skill": "perception",
+        "dc": 12,
+        "on_success": "Du findest eine Falle.",
+        "on_fail": "Du löst eine Falle aus."
+      }
+    }
+  ],
+  "combat_if_triggered": {
+    "monsters": ["Goblin"],
+    "tactics": "Hinterhalt aus dem Schatten",
+    "terrain": "Höhle",
+    "scaling": "medium"
+  },
+  "state_updates": []
+}

--- a/tests/golden_samples/compose_scene_valid.json
+++ b/tests/golden_samples/compose_scene_valid.json
@@ -1,0 +1,22 @@
+{
+  "scene_id": 1,
+  "narration": "Die Helden betreten eine dunkle Höhle.",
+  "options": [
+    {
+      "prompt": "Nach Fallen suchen",
+      "check": {
+        "skill": "perception",
+        "dc": 12,
+        "on_success": "Du findest eine Falle.",
+        "on_fail": "Du löst eine Falle aus."
+      }
+    }
+  ],
+  "combat_if_triggered": {
+    "monsters": ["Goblin"],
+    "tactics": "Hinterhalt aus dem Schatten",
+    "terrain": "Höhle",
+    "scaling": "medium"
+  },
+  "state_updates": []
+}

--- a/tests/test_llm_compose_scene.py
+++ b/tests/test_llm_compose_scene.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import logging
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routes.llm import get_llm
+
+SAMPLES = Path("tests/golden_samples")
+
+
+def override(llm_func):
+    app.dependency_overrides[get_llm] = lambda: llm_func
+
+
+def test_compose_scene_ok() -> None:
+    sample = SAMPLES / "compose_scene_valid.json"
+
+    def llm_stub(_: list[dict]) -> str:
+        return sample.read_text()
+
+    override(llm_stub)
+    with TestClient(app) as client:
+        res = client.post(
+            "/llm/compose_scene", json={"scene_id": 1, "party": {"members": ["A"]}}
+        )
+    app.dependency_overrides.clear()
+    assert res.status_code == 200
+    assert res.json() == json.loads(sample.read_text())
+
+
+def test_compose_scene_retry(caplog) -> None:
+    caplog.set_level(logging.INFO)
+    responses = [
+        (SAMPLES / "compose_scene_missing_field.json").read_text(),
+        (SAMPLES / "compose_scene_valid.json").read_text(),
+    ]
+
+    def llm_stub(_: list[dict]) -> str:
+        return responses.pop(0)
+
+    override(llm_stub)
+    with TestClient(app) as client:
+        res = client.post(
+            "/llm/compose_scene", json={"scene_id": 1, "party": {"members": ["A"]}}
+        )
+    app.dependency_overrides.clear()
+    assert res.status_code == 200
+    assert res.json()["narration"]
+    assert any("invalid on attempt 1" in r.message for r in caplog.records)
+
+
+def test_compose_scene_fail() -> None:
+    sample = (SAMPLES / "compose_scene_missing_field.json").read_text()
+
+    def llm_stub(_: list[dict]) -> str:
+        return sample
+
+    override(llm_stub)
+    with TestClient(app) as client:
+        res = client.post(
+            "/llm/compose_scene", json={"scene_id": 1, "party": {"members": ["A"]}}
+        )
+    app.dependency_overrides.clear()
+    assert res.status_code == 422

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+import logging
+
+import pytest
+from fastapi import HTTPException
+
+from app.llm.templates import DEVELOPER_PROMPT, SYSTEM_PROMPT
+from app.llm.validate import validate_with_retry
+
+SAMPLES = Path("tests/golden_samples")
+
+
+def test_validate_success() -> None:
+    sample = SAMPLES.joinpath("compose_scene_valid.json").read_text()
+
+    def llm_stub(_: list[dict]) -> str:
+        return sample
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "developer", "content": DEVELOPER_PROMPT},
+    ]
+    result = validate_with_retry(llm_stub, messages)
+    assert result.scene_id == 1
+
+
+def test_validate_retry(caplog) -> None:
+    caplog.set_level(logging.INFO)
+    responses = [
+        SAMPLES.joinpath("compose_scene_missing_field.json").read_text(),
+        SAMPLES.joinpath("compose_scene_valid.json").read_text(),
+    ]
+
+    def llm_stub(_: list[dict]) -> str:
+        return responses.pop(0)
+
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+    result = validate_with_retry(llm_stub, messages)
+    assert result.narration
+    assert any("invalid on attempt 1" in r.message for r in caplog.records)
+
+
+def test_validate_fail_after_retries() -> None:
+    sample = SAMPLES.joinpath("compose_scene_missing_field.json").read_text()
+
+    def llm_stub(_: list[dict]) -> str:
+        return sample
+
+    with pytest.raises(HTTPException):
+        validate_with_retry(llm_stub, [])


### PR DESCRIPTION
## Summary
- add Co-DM prompt templates and strict output schema
- validate LLM JSON with retry logic
- expose `/llm/compose_scene` for deterministic scene composition
- document schema and usage

## Testing
- `pre-commit run --files app/llm/templates.py app/routes/llm.py tests/test_llm_validate.py`
- `pre-commit run --files tests/test_llm_compose_scene.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987b17e1d0832bbc1a49bf3bed42c8